### PR TITLE
Do not swallow interrupts in awaitTermination

### DIFF
--- a/src/main/java/au/com/ds/ef/StatefulContext.java
+++ b/src/main/java/au/com/ds/ef/StatefulContext.java
@@ -117,7 +117,7 @@ public class StatefulContext implements Serializable {
         try {
             this.completionLatch.await();
         } catch (InterruptedException e) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
         }
     }
 


### PR DESCRIPTION
`awaitTermination` in `StatefulContext` seems like it's about to do the right thing and put back the thread's interrupted bit if it gets interrupted while waiting, but instead it calls the wrong method*. This means that once `awaitTermination`, calling code will have no idea the thread was interrupted.

This PR fixes this by putting the thread's interrupt flag back, so calling code can do something with this information if it wants.

\* - Regardless of intention, this has to be the wrong method because `Thread.interrupted()` is 100% guaranteed to do nothing  in this case, the thread's interrupted state just got reset as we're catching InterruptedException, `Thread.interrupted()` will just return false and not change anything.