### PR TITLE
Make FlowBuilder stateless

### DIFF
--- a/src/main/java/au/com/ds/ef/FlowBuilder.java
+++ b/src/main/java/au/com/ds/ef/FlowBuilder.java
@@ -56,8 +56,9 @@ public class FlowBuilder<C extends StatefulContext> {
         return this;
 	}
 
-    public void setExecutor(Executor executor) {
+    public FlowBuilder<C> setExecutor(Executor executor) {
         this.executor = executor;
+        return this;
     }
 
     public <C1 extends StatefulContext> EasyFlow<C1> build() {

--- a/src/main/java/au/com/ds/ef/FlowBuilder.java
+++ b/src/main/java/au/com/ds/ef/FlowBuilder.java
@@ -1,11 +1,13 @@
 package au.com.ds.ef;
 
 import java.util.Collection;
+import java.util.concurrent.Executor;
 
 public class FlowBuilder<C extends StatefulContext> {
 
     private StateEnum startState;
     private boolean skipValidation;
+    private Executor executor;
 
     public static class ToHolder {
         private EventEnum event;
@@ -54,9 +56,14 @@ public class FlowBuilder<C extends StatefulContext> {
         return this;
 	}
 
+    public void setExecutor(Executor executor) {
+        this.executor = executor;
+    }
+
     public <C1 extends StatefulContext> EasyFlow<C1> build() {
         EasyFlow<C1> flow = new EasyFlow<C1>(startState);
         flow.processAllTransitions(skipValidation);
+        if (executor != null) flow.executor(executor);
         return flow;
     }
 }

--- a/src/main/java/au/com/ds/ef/FlowBuilder.java
+++ b/src/main/java/au/com/ds/ef/FlowBuilder.java
@@ -3,7 +3,9 @@ package au.com.ds.ef;
 import java.util.Collection;
 
 public class FlowBuilder<C extends StatefulContext> {
-	private EasyFlow<C> flow;
+
+    private StateEnum startState;
+    private boolean skipValidation;
 
     public static class ToHolder {
         private EventEnum event;
@@ -22,7 +24,7 @@ public class FlowBuilder<C extends StatefulContext> {
     }
 
 	private FlowBuilder(StateEnum startState) {
-        flow = new EasyFlow<C>(startState);
+        this.startState = startState;
 	}
 
 	public static <C extends StatefulContext> FlowBuilder<C> from(StateEnum startState) {
@@ -40,16 +42,21 @@ public class FlowBuilder<C extends StatefulContext> {
         return new ToHolder(event);
     }
 
-    public <C1 extends StatefulContext> EasyFlow<C1> transit(Transition... transitions) {
+    public FlowBuilder<C> transit(Transition... transitions) {
         return transit(false, transitions);
     }
 
-	public <C1 extends StatefulContext> EasyFlow<C1> transit(boolean skipValidation, Transition... transitions) {
+	public FlowBuilder<C> transit(boolean skipValidation, Transition... transitions) {
         for (Transition transition : transitions) {
-            transition.setStateFrom(flow.getStartState());
+            transition.setStateFrom(startState);
         }
-		flow.processAllTransitions(skipValidation);
-
-        return (EasyFlow<C1>) flow;
+        this.skipValidation = skipValidation;
+        return this;
 	}
+
+    public <C1 extends StatefulContext> EasyFlow<C1> build() {
+        EasyFlow<C1> flow = new EasyFlow<C1>(startState);
+        flow.processAllTransitions(skipValidation);
+        return flow;
+    }
 }

--- a/src/main/java/au/com/ds/ef/StatefulContext.java
+++ b/src/main/java/au/com/ds/ef/StatefulContext.java
@@ -79,6 +79,10 @@ public class StatefulContext implements Serializable {
     protected void setFlow(EasyFlow<? extends StatefulContext> flow) {
         this.flow = flow;
     }
+
+    protected EasyFlow getFlow() {
+        return flow;
+    }
 	
 	protected String newId() {
 		return Long.toString(idCounter++);

--- a/src/test/java/au/com/ds/ef/JsonArrayParserTest.java
+++ b/src/test/java/au/com/ds/ef/JsonArrayParserTest.java
@@ -189,7 +189,7 @@ public class JsonArrayParserTest {
                     on(contentValid).finish(DONE),
                     on(contentInvalid).finish(ERROR)
                 )
-            );
+            ).build();
 
         flow
             .executor(new SyncExecutor())

--- a/src/test/java/au/com/ds/ef/RunSingleTest.java
+++ b/src/test/java/au/com/ds/ef/RunSingleTest.java
@@ -39,7 +39,7 @@ public class RunSingleTest {
                 on(event_1).to(STATE_1).transit(
                     on(event_2).finish(STATE_2)
                 )
-            );
+            ).build();
 
         // handlers definition
         flow
@@ -78,7 +78,7 @@ public class RunSingleTest {
                         on(event_5).finish(STATE_4)
                     )
                 )
-		    );
+		    ).build();
 
 		final List<Integer> actualOrder = new ArrayList<Integer>();
 
@@ -234,7 +234,7 @@ public class RunSingleTest {
                     on(event_2).finish(STATE_3),
                     on(event_1).finish(STATE_4)
                 )
-            );
+            ).build();
 
         flow
             .whenEnter(START, new ContextHandler<StatefulContext>() {
@@ -269,7 +269,7 @@ public class RunSingleTest {
                     on(event_2).finish(STATE_3),
                     on(event_1).finish(STATE_4)
                 )
-            );
+            ).build();
 
         flow
             .whenEnter(START, new ContextHandler<StatefulContext>() {
@@ -307,7 +307,7 @@ public class RunSingleTest {
                                 on(event_2).finish(STATE_3),
                                 on(event_1).finish(STATE_4)
                         )
-                );
+                ).build();
 
         final boolean[] whenEnterCalled = {false};
 

--- a/src/test/java/au/com/ds/ef/SynchronizationTest.java
+++ b/src/test/java/au/com/ds/ef/SynchronizationTest.java
@@ -53,7 +53,7 @@ public class SynchronizationTest {
                     on(initialize).to(RUNNING).transit(
                         on(terminate).finish(DONE)
                     )
-                );
+                ).build();
 
             flow
                 .whenEnter(UNINITIALIZED, new ContextHandler<StatefulContext>() {

--- a/src/test/java/au/com/ds/ef/ValidationTest.java
+++ b/src/test/java/au/com/ds/ef/ValidationTest.java
@@ -18,7 +18,7 @@ public class ValidationTest {
 	@Test(expected = DefinitionError.class)
     // no transitions defined
 	public void testLooseEnd1() {
-		from(START).transit();
+		from(START).transit().build();
 	}
 	
 	@Test(expected = DefinitionError.class)
@@ -26,7 +26,7 @@ public class ValidationTest {
 	public void testLooseEnd2() {
 		from(START).transit(
 			on(event_1).to(STATE_1)
-		);
+		).build();
 	}
 	
 	@Test(expected = DefinitionError.class)
@@ -34,7 +34,7 @@ public class ValidationTest {
 	public void testLooseEnd3() {
 		from(START).transit(
 			on(event_1).to(STATE_1).transit()
-		);
+		).build();
 	}
 	
 	@Test(expected = DefinitionError.class)
@@ -44,7 +44,7 @@ public class ValidationTest {
 			on(event_1).finish(STATE_1).transit(
 				on(event_2).to(STATE_2)
 			)
-		);
+		).build();
 	}
 	
 	@Test
@@ -67,7 +67,7 @@ public class ValidationTest {
             on(event_1).to(STATE_2).transit(
                 on(event_3).finish(STATE_3)
             )
-		);
+		).build();
 	}
 
 	@Test(expected = DefinitionError.class)
@@ -79,7 +79,7 @@ public class ValidationTest {
             on(event_1).to(STATE_1).transit(
                 on(event_3).finish(STATE_3)
             )
-		);
+		).build();
 	}
 
 	@Test(expected = DefinitionError.class)
@@ -87,7 +87,7 @@ public class ValidationTest {
 		from(START).transit(
 			on(event_1).to(START),
             on(event_2).finish(STATE_2)
-		);
+		).build();
 	}
 	
 	@Test


### PR DESCRIPTION
Make FlowBuilder stateless so it could build multiple EasyFlow instances with different event callback, so these instances could be used in different scenarios, e.g. ViewController(Activity) or Backend service.

This modification will break original api a little bit.